### PR TITLE
Fix warning about altering Ruby constant

### DIFF
--- a/lib/carrierwave/httparty_monkey.rb
+++ b/lib/carrierwave/httparty_monkey.rb
@@ -7,7 +7,7 @@ require 'httparty'
 module HTTParty
 
   class Request
-    SupportedHTTPMethods += [Net::HTTP::Mkcol, Net::HTTP::Propfind]
+    SupportedHTTPMethods << Net::HTTP::Mkcol << Net::HTTP::Propfind
   end
 
   module ClassMethods


### PR DESCRIPTION
carrierwave-webdav/lib/carrierwave/httparty_monkey.rb:10: warning: already initialized constant HTTParty::Request::SupportedHTTPMethods
httparty-0.13.7/lib/httparty/request.rb:3: warning: previous definition of SupportedHTTPMethods was here
